### PR TITLE
Address ioda hv filename bug

### DIFF
--- a/src/score_hv/harvester_base.py
+++ b/src/score_hv/harvester_base.py
@@ -42,17 +42,14 @@ def harvest(harvest_config):
     # harvesters).
     try:
         harvester_name = harvest_dict.get('harvester_name')
-        print(f'harvester_name: {harvester_name}')
-        print(f'harvester_registry: {hvr.harvester_registry}, ' \
-                f'type(harvester_registry): {type(hvr.harvester_registry)}')
         harvester = hvr.harvester_registry.get(harvester_name)
     except Exception as err:
-        msg = f'could not find harvester from config: {harvest_dict}'
+        msg = f'could not find harvester from config: {harvest_dict}\n'
+        msg += f'valid harvester registry options: {hvr.harvester_registry}'
         raise KeyError(msg) from err
 
-    print(f'harvester_name: {harvester_name}')
+    print(f'running harvester: {harvester_name}')
     config = harvester.config_handler(harvest_dict)
-    print(f'type(config): {type(config)}')
     return harvester.data_parser(config).get_data()
 
 

--- a/src/score_hv/harvesters/ioda_meta_netcdf.py
+++ b/src/score_hv/harvesters/ioda_meta_netcdf.py
@@ -243,7 +243,7 @@ def parse_filename(file_path):
     filename = os.path.basename(file_path)
     
     # Regular expression to match the filename pattern
-    pattern = r'.*\.(\d{8})\.T(\d{6})Z\.ioda(v\d+)\b.*\.nc$'
+    pattern = r'.*?(\d{8})\.T(\d{6})Z?\.ioda(v\d+)\b.*\.nc$'
     
     match = re.match(pattern, filename)
     if match:


### PR DESCRIPTION
This PR addresses a bug identified in the ioda_meta_netcdf harvester where there was a required expectation of a . prior to datetime (instead of allowing _ which also occur often in our NNJA file names) and Z (after the datetime) which are not always required in the filename format. To address this the regular expression was updated to a lazy ? interpretation of these two values with no actual impact to the values actually being parsed for datetime and ioda version. 

As a result of addressing this error, it was also determined there are superfluous print statements in the main harvester call code which was producing excess output and making identifying problems more difficult. To address this, I moved the printed information to be reduced and print registry information only upon an error when that information will be useful. 

Tests are running successfully. 