### PR TITLE
change default region from NoneType to "global" for SOCA metrics

### DIFF
--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -76,7 +76,7 @@ def parse_filename(filename):
        filename_info['sensor'] = None
 
     filename_info['datetime'] = datetime_part 
-    filename_info['region'] = None
+    filename_info['region'] = 'global'
     filename_info['satellite'] = None
     filename_info['level'] = None
     if len(parts) == 3:

--- a/tests/test_insitu_surface.py
+++ b/tests/test_insitu_surface.py
@@ -50,7 +50,8 @@ def test_verify_filename_components():
            raise ValueError(f"Error: {item.variables} is not in the expected variable list.")  
         assert item.sensor == None   
         assert item.satellite == 'trkob'
-        assert item.level == None   
+        assert item.level == None
+        assert item.file_region == 'global'
 
 def test_verify_datetime():
     data1 = harvest(VALID_CONFIG_DICT)


### PR DESCRIPTION
Includes a one line change to the soca_diags.py harvester and an additional assert added to an existing unit test.

This change is necessary for compatibility with score_db, which requires a region name when adding metrics to the relational database.

All tests passing as expected.