### PR TITLE
Bug fix: wod insitu harvester

### DIFF
--- a/src/score_hv/harvesters/wod_insitu_meta_netcdf.py
+++ b/src/score_hv/harvesters/wod_insitu_meta_netcdf.py
@@ -107,27 +107,28 @@ class WodInsituMetaHv:
             for dim in dataset.dimensions
             if dim.endswith("_obs") and dim not in {"z_obs", "JulianDay_obs", "Latitude_obs", "Longitude_obs"}
         }
-        
+
         min_file_depth = None
         max_file_depth = None
         #get the min and max depth as appropriate
         if 'z' in dataset.variables:
             z_var = dataset.variables['z'][:]
-            min_file_depth = np.min(z_var) if np.issubdtype(z_var.dtype, np.floating) else None
-            max_file_depth = np.max(z_var) if np.issubdtype(z_var.dtype, np.floating) else None
+            if z_var.size > 0: #if there's no depth values, continue on
+                min_file_depth = np.min(z_var) if np.issubdtype(z_var.dtype, np.floating) else None
+                max_file_depth = np.max(z_var) if np.issubdtype(z_var.dtype, np.floating) else None
 
-            #make sure to get min and max depth for the variable size, in case it differs 
-            start = 0
-            for var, stats in variable_counts.items():
-                size = stats['count']
-                if size == 0:
-                    continue
+                #make sure to get min and max depth for the variable size, in case it differs 
+                start = 0
+                for var, stats in variable_counts.items():
+                    size = stats['count']
+                    if size == 0:
+                        continue
 
-                # Extract corresponding depths using the range from start to start+size
-                var_depths = z_var[start:start+size]
-                if len(var_depths) > 0:
-                    variable_counts[var]['min_depth'] = np.nanmin(var_depths)
-                    variable_counts[var]['max_depth'] = np.nanmax(var_depths)
+                    # Extract corresponding depths using the range from start to start+size
+                    var_depths = z_var[start:start+size]
+                    if len(var_depths) > 0:
+                        variable_counts[var]['min_depth'] = np.nanmin(var_depths)
+                        variable_counts[var]['max_depth'] = np.nanmax(var_depths)
 
         #get the number of casts
         casts = None

--- a/tests/test_harvester_wod_insitu_meta_netcdf.py
+++ b/tests/test_harvester_wod_insitu_meta_netcdf.py
@@ -14,6 +14,7 @@ WOD_GLD_DATA = 'wod_gld_2013-06-02T06.nc'
 WOD_MBT_DATA = 'wod_mbt_1989-12-13T00.nc'
 WOD_MRB_DATA = 'wod_mrb_1983-06-03T12.nc'
 WOD_OSD_DATA = 'wod_osd_1998-05-02T00.nc'
+WOD_OSD_DATA_1995 = 'wod_osd_1995-01-01T00.nc'
 WOD_PFL_DATA = 'wod_pfl_2019-10-01T18.nc'
 WOD_UOR_DATA = 'wod_uor_2002-10-06T18.nc'
 WOD_XBT_DATA = 'wod_xbt_2009-08-02T18.nc'
@@ -28,6 +29,7 @@ file_path_wod_gld_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_GLD_DATA
 file_path_wod_mbt_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_MBT_DATA)
 file_path_wod_mrb_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_MRB_DATA)
 file_path_wod_osd_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_OSD_DATA)
+file_path_wod_osd_1995_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_OSD_DATA_1995)
 file_path_wod_pfl_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_PFL_DATA)
 file_path_wod_uor_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_UOR_DATA)
 file_path_wod_xbt_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, WOD_XBT_DATA)
@@ -65,6 +67,11 @@ VALID_CONFIG_WOD_MRB = {
 VALID_CONFIG_WOD_OSD = {
     'harvester_name': hv_registry.WOD_INSITU_META_NETCDF,
     'filename': file_path_wod_osd_data
+}
+
+VALID_CONFIG_WOD_OSD_1995 = {
+    'harvester_name': hv_registry.WOD_INSITU_META_NETCDF,
+    'filename': file_path_wod_osd_1995_data
 }
 
 VALID_CONFIG_WOD_PFL = {
@@ -203,6 +210,23 @@ def test_wod_osd_meta():
     assert cfc11_obs.var_count == 8651
     assert cfc11_obs.sensor == "osd"
     assert cfc11_obs.casts == 35
+
+def test_wod_osd_1995_meta():
+    data = harvest(VALID_CONFIG_WOD_OSD_1995)
+    cfc11_obs = data[11]
+    assert cfc11_obs.filename == WOD_OSD_DATA_1995
+    assert cfc11_obs.obs_day == "1995-01-01 00:00:00"
+    assert cfc11_obs.min_date_time == None
+    assert cfc11_obs.max_date_time == None
+    assert cfc11_obs.min_depth == None
+    assert cfc11_obs.max_depth == None
+    assert cfc11_obs.min_file_depth == None
+    assert cfc11_obs.max_file_depth == None
+    assert cfc11_obs.num_vars == 21
+    assert cfc11_obs.variable_name == "CFC11"
+    assert cfc11_obs.var_count == 53766
+    assert cfc11_obs.sensor == "osd"
+    assert cfc11_obs.casts == 8
 
 def test_wod_pfl_meta():
     data = harvest(VALID_CONFIG_WOD_PFL)


### PR DESCRIPTION
This PR adds a bug fix to the harvester for wod insitu data to handle an unforeseen data problem where the file does not contain any depth values. This is necessary to be able to inventory and identify for the observation inventory code as well as prevent errors which crash the harvester. 

An example file of this case has been added to the test data and in the harvester tests to show the file can now be processed successfully. 