### PR TITLE
Add netcdf ozone harvester

### DIFF
--- a/src/score_hv/harvesters/ozone_meta_netcdf.py
+++ b/src/score_hv/harvesters/ozone_meta_netcdf.py
@@ -1,0 +1,179 @@
+"""
+Copyright 2025 NOAA
+All rights reserved.
+
+Collection of methods to retrieve metadata from formatted nc files for ozone data.
+
+"""
+from collections import namedtuple
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from netCDF4 import Dataset, num2date
+import re
+import os 
+import numpy as np
+
+from score_hv.config_base import ConfigInterface
+
+HARVESTER_NAME = 'ozone_meta_netcdf'
+
+HarvestedData = namedtuple(
+    'HarvestedData',
+    [
+        'filename',
+        'obs_day',
+        'min_date_time',
+        'max_date_time',
+        'min_pressure',
+        'max_pressure',
+        'ozone_count',
+        'sensor'
+    ]
+)
+
+@dataclass
+class OzoneMetaCfg(ConfigInterface):
+    """
+        Dataclass to hold and provide configuration information pertaining to
+        how the harvester should retrieve the ozone metadata.
+    
+        Parameters:
+        -----------
+        config_data: dict - contains configuration data parsed from either an
+                            input yaml file or input dict
+    """
+
+    config_data: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+         self.set_config()
+    
+    def set_config(self):
+        """ function to set configuration variables from given dictionary
+        """ 
+        self.harvest_filename = self.config_data.get('filename')
+
+@dataclass
+class OzoneMetaHv:
+    """
+    Harvester dataclass used to parse metadata from ozone nc files
+
+    Parameters:
+    -----------
+    config: OzoneMetaCfg object containing information used to determine what file to get info for
+
+    Methods:
+    --------
+    get_data: gets the metadata for a specified file in netcdf format
+    """
+    config: OzoneMetaCfg = field(default_factory=OzoneMetaCfg)
+
+    def get_data(self):
+        """
+        Harvests metadata for ozone netcdf files including number of observations and min and max pressure. 
+
+        Returns
+        -------
+        harvested_data: list of Harvested data for a given file, one per variable, some data is file level for every variable
+
+        'filename',
+        'obs_day',
+        'min_date_time',
+        'max_date_time',
+        'min_pressure',
+        'max_pressure',
+        'ozone_count',
+        'sensor
+        """
+        harvested_data = []
+        dataset = Dataset(self.config.harvest_filename, 'r')
+
+
+        # --- Get ozone data (2D: nprofiles x nlevs) ---
+        ozone = dataset.variables['ozone'][:]  # shape: (nprofiles, nlevs)
+        valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
+
+        # --- Read profile-level datetime components ---
+        year   = np.ma.filled(dataset.variables['year'][:], np.nan)
+        month  = np.ma.filled(dataset.variables['month'][:], np.nan)
+        day    = np.ma.filled(dataset.variables['day'][:], np.nan)
+        hour   = np.ma.filled(dataset.variables['hour'][:], np.nan)
+        minute = np.ma.filled(dataset.variables['minute'][:], np.nan)
+        second = np.ma.filled(dataset.variables['second'][:], np.nan)
+        press = np.ma.filled(dataset.variables['press'][:], np.nan) 
+
+
+        # --- Build datetime objects safely ---
+        nprofiles = len(year)
+        datetimes = []
+
+        for i in range(nprofiles):
+            components = [year[i], month[i], day[i], hour[i], minute[i], second[i]]
+            if np.isnan(components).any():
+                continue
+            try:
+                dt = datetime(int(year[i]), int(month[i]), int(day[i]),
+                            int(hour[i]), int(minute[i]), int(second[i]))
+                datetimes.append(dt)
+            except (ValueError, TypeError):
+                continue
+        
+        min_dt = None
+        max_dt = None
+        if datetimes:
+            min_dt = format_datetime_string(min(datetimes))
+            max_dt = format_datetime_string(max(datetimes))
+
+        # --- Compute min and max pressure, excluding NaNs ---
+        min_press = np.nanmin(press)
+        max_press = np.nanmax(press)
+       
+
+        filename_parsed = parse_filename(self.config.harvest_filename) 
+        sensor = filename_parsed['sensor']
+        filename = filename_parsed['filename']
+        obs_day = filename_parsed['formatted_datetime_str']
+
+        harvested_data.append(
+            HarvestedData(
+                filename,
+                obs_day,
+                min_dt,
+                max_dt,
+                min_press, 
+                max_press,
+                valid_ozone_count,
+                sensor, 
+            )
+        )
+
+        return harvested_data
+
+
+def format_datetime_string(datetime_obj):
+    return datetime_obj.strftime("%Y-%m-%d %H:%M:%S")
+
+def parse_filename(file_path):
+    # Extract the file name from the full path
+    filename = os.path.basename(file_path)
+    
+    # Regular expression to match the filename pattern
+    pattern = r'^(?P<sensor>[^.]+)\.(?P<date>\d{8})_(?P<hour>\d{2})z\.nc$'
+    
+    match = re.match(pattern, filename)
+    if match:
+        sensor = match.group("sensor")
+        date_str = match.group("date")
+        hour_str = match.group("hour")
+
+        dt_obj = datetime.strptime(date_str + hour_str, "%Y%m%d%H")        
+        formatted_datetime_str = format_datetime_string(dt_obj)
+        
+        return {
+            'filename': filename,
+            'formatted_datetime_str': formatted_datetime_str,
+            'datetime_obj': dt_obj,
+            'sensor': sensor
+        }
+    else:
+        raise ValueError(f"Filename '{filename}' does not match the expected ozone netcdf format pattern.")

--- a/src/score_hv/harvesters/ozone_meta_netcdf.py
+++ b/src/score_hv/harvesters/ozone_meta_netcdf.py
@@ -24,6 +24,8 @@ HarvestedData = namedtuple(
         'obs_day',
         'min_date_time',
         'max_date_time',
+        'levels',
+        'profiles',
         'min_pressure',
         'max_pressure',
         'ozone_count',
@@ -90,8 +92,14 @@ class OzoneMetaHv:
 
 
         # --- Get ozone data (2D: nprofiles x nlevs) ---
-        ozone = dataset.variables['ozone'][:]  # shape: (nprofiles, nlevs)
-        valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
+        if 'ozone' in dataset.variables:
+            ozone = dataset.variables['ozone'][:]  # shape: (nprofiles, nlevs)
+            valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
+        
+        # --- Get ozone data in 1D nrec 
+        if 'toz' in dataset.variables:
+            ozone = dataset.variables['toz'][:]  # shape: (nrec)
+            valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
 
         # --- Read profile-level datetime components ---
         year   = np.ma.filled(dataset.variables['yy'][:], np.nan)
@@ -100,8 +108,6 @@ class OzoneMetaHv:
         hour   = np.ma.filled(dataset.variables['hh'][:], np.nan)
         minute = np.ma.filled(dataset.variables['min'][:], np.nan)
         second = np.ma.filled(dataset.variables['ss'][:], np.nan)
-        press = np.ma.filled(dataset.variables['press'][:], np.nan) 
-
 
         # --- Build datetime objects safely ---
         nprofiles = len(year)
@@ -124,10 +130,23 @@ class OzoneMetaHv:
             min_dt = format_datetime_string(min(datetimes))
             max_dt = format_datetime_string(max(datetimes))
 
-        # --- Compute min and max pressure, excluding NaNs ---
-        min_press = np.nanmin(press)
-        max_press = np.nanmax(press)
-       
+        min_press = None
+        max_press = None
+        if 'press' in dataset.variables:
+            press = np.ma.filled(dataset.variables['press'][:], np.nan) 
+            # --- Compute min and max pressure, excluding NaNs ---
+            min_press = np.nanmin(press)
+            max_press = np.nanmax(press)
+
+        levels = None
+        if 'nlevs' in dataset.dimensions:
+            levels = len(dataset.dimensions['nlevs'])
+
+        profiles = None
+        if 'nrec' in dataset.dimensions:
+            profiles = len(dataset.dimensions['nrec'])
+        elif 'nprofiles' in dataset.dimensions:
+            profiles = len(dataset.dimensions['nprofiles'])
 
         filename_parsed = parse_filename(self.config.harvest_filename) 
         sensor = filename_parsed['sensor']
@@ -140,6 +159,8 @@ class OzoneMetaHv:
                 obs_day,
                 min_dt,
                 max_dt,
+                levels,
+                profiles,
                 min_press, 
                 max_press,
                 valid_ozone_count,

--- a/src/score_hv/harvesters/ozone_meta_netcdf.py
+++ b/src/score_hv/harvesters/ozone_meta_netcdf.py
@@ -94,12 +94,12 @@ class OzoneMetaHv:
         valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
 
         # --- Read profile-level datetime components ---
-        year   = np.ma.filled(dataset.variables['year'][:], np.nan)
-        month  = np.ma.filled(dataset.variables['month'][:], np.nan)
-        day    = np.ma.filled(dataset.variables['day'][:], np.nan)
-        hour   = np.ma.filled(dataset.variables['hour'][:], np.nan)
-        minute = np.ma.filled(dataset.variables['minute'][:], np.nan)
-        second = np.ma.filled(dataset.variables['second'][:], np.nan)
+        year   = np.ma.filled(dataset.variables['yy'][:], np.nan)
+        month  = np.ma.filled(dataset.variables['mm'][:], np.nan)
+        day    = np.ma.filled(dataset.variables['dd'][:], np.nan)
+        hour   = np.ma.filled(dataset.variables['hh'][:], np.nan)
+        minute = np.ma.filled(dataset.variables['min'][:], np.nan)
+        second = np.ma.filled(dataset.variables['ss'][:], np.nan)
         press = np.ma.filled(dataset.variables['press'][:], np.nan) 
 
 
@@ -158,7 +158,7 @@ def parse_filename(file_path):
     filename = os.path.basename(file_path)
     
     # Regular expression to match the filename pattern
-    pattern = r'^(?P<sensor>[^.]+)\.(?P<date>\d{8})_(?P<hour>\d{2})z\.nc$'
+    pattern = r'^(?P<sensor>.+)\.(?P<date>\d{8})_(?P<hour>\d{2})z\.nc$'
     
     match = re.match(pattern, filename)
     if match:

--- a/src/score_hv/hv_registry.py
+++ b/src/score_hv/hv_registry.py
@@ -14,6 +14,7 @@ from score_hv.harvesters.soca_diags import SOCADiagsConfig, SOCADiagsHv
 from score_hv.harvesters.gsi_satellite_radiance_channel import GSISatelliteRadianceChannelConfig, GSISatelliteRadianceChannelHv
 from score_hv.harvesters.ioda_meta_netcdf import IodaMetaCfg, IodaMetaHv
 from score_hv.harvesters.wod_insitu_meta_netcdf import WodInsituMetaCfg, WodInsituMetaHv
+from score_hv.harvesters.ozone_meta_netcdf import OzoneMetaCfg, OzoneMetaHv
 
 NAMED_TUPLES_LIST = 'tuples_list'
 PANDAS_DATAFRAME = 'pandas_dataframe'
@@ -26,6 +27,7 @@ SOCA_DIAGS = 'soca_diags'
 GSI_SATELLITE_RADIANCE_CHANNEL = 'gsi_satellite_radiance_channel'
 IODA_META_NETCDF = 'ioda_meta_netcdf'
 WOD_INSITU_META_NETCDF = 'wod_insitu_meta_netcdf'
+OZONE_META_NETCDF = 'ozone_meta_netcdf'
 
 Harvester = namedtuple('Harvester', ('name', 'config_handler', 'data_parser'),)
 
@@ -72,5 +74,9 @@ harvester_registry = {INNOV_NETCDF: Harvester(
                       WOD_INSITU_META_NETCDF: Harvester(
                           'meta data contained in wod insitu netcdf files',
                           WodInsituMetaCfg,
-                          WodInsituMetaHv)
+                          WodInsituMetaHv),
+                      OZONE_META_NETCDF: Harvester(
+                          'meta data in netcdf files containing ozone data',
+                          OzoneMetaCfg,
+                          OzoneMetaHv),
                       }

--- a/tests/test_harvester_ozone_meta_netcdf.py
+++ b/tests/test_harvester_ozone_meta_netcdf.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import os
+from pathlib import Path
+import numpy
+
+from score_hv import hv_registry
+from score_hv.harvester_base import harvest
+
+PYTEST_CALLING_DIR = Path(__file__).parent.resolve()
+DATA_DIR = 'data'
+
+OZONE_MLS_DATA = 'MLS-v5.0-oz.20040803_00z.nc'
+
+file_path_ozone_mls_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_MLS_DATA)
+
+VALID_CONFIG_OZONE_MLS = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_mls_data
+}
+
+def test_ozone_mls_meta():
+    data = harvest(VALID_CONFIG_OZONE_MLS)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_MLS_DATA
+    assert ozone_data.obs_day == '2004-08-03 00:00:00'
+    assert ozone_data.min_date_time == '2004-08-02 22:36:58'
+    assert ozone_data.max_date_time == '2004-08-03 02:59:38'
+    assert numpy.isclose(ozone_data.min_pressure, 0.001)
+    assert numpy.isclose(ozone_data.max_pressure, 261.01572)
+    assert ozone_data.ozone_count == 34705
+    assert ozone_data.sensor == 'MLS-v5.0-oz'

--- a/tests/test_harvester_ozone_meta_netcdf.py
+++ b/tests/test_harvester_ozone_meta_netcdf.py
@@ -11,12 +11,40 @@ PYTEST_CALLING_DIR = Path(__file__).parent.resolve()
 DATA_DIR = 'data'
 
 OZONE_MLS_DATA = 'MLS-v5.0-oz.20040803_00z.nc'
+OZONE_OMI_EFF_DATA = 'OMIeff-adj.20130512_06z.nc'
+OZONE_OMPSLP_DATA = 'OMPS-LPoz-Vis.20181003_18z.nc'
+OZONE_OMPSNM_DATA = 'OMPSNM.20121203_00z.nc'
+OZONE_OMPSNP_DATA = 'OMPSNP.20211002_18z.nc'
 
 file_path_ozone_mls_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_MLS_DATA)
+file_path_ozone_omi_eff_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMI_EFF_DATA)
+file_path_ozone_omsplp_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSLP_DATA)
+file_path_ozone_ompsnm_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSNM_DATA)
+file_path_ozone_ompsnp_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSNP_DATA)
 
 VALID_CONFIG_OZONE_MLS = {
     'harvester_name': hv_registry.OZONE_META_NETCDF,
     'filename': file_path_ozone_mls_data
+}
+
+VALID_CONFIG_OZONE_OMI_EFF = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_omi_eff_data
+}
+
+VALID_CONFIG_OZONE_OMPSLP = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_omsplp_data
+}
+
+VALID_CONFIG_OZONE_OMPSNM = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_ompsnm_data
+}
+
+VALID_CONFIG_OZONE_OMPSNP = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_ompsnp_data
 }
 
 def test_ozone_mls_meta():
@@ -26,7 +54,65 @@ def test_ozone_mls_meta():
     assert ozone_data.obs_day == '2004-08-03 00:00:00'
     assert ozone_data.min_date_time == '2004-08-02 22:36:58'
     assert ozone_data.max_date_time == '2004-08-03 02:59:38'
+    assert ozone_data.levels == 55
+    assert ozone_data.profiles == 631
     assert numpy.isclose(ozone_data.min_pressure, 0.001)
     assert numpy.isclose(ozone_data.max_pressure, 261.01572)
     assert ozone_data.ozone_count == 34705
     assert ozone_data.sensor == 'MLS-v5.0-oz'
+
+def test_ozone_omi_eff_meta():
+    data = harvest(VALID_CONFIG_OZONE_OMI_EFF)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_OMI_EFF_DATA
+    assert ozone_data.obs_day == '2013-05-12 06:00:00'
+    assert ozone_data.min_date_time == '2013-05-12 03:40:11'
+    assert ozone_data.max_date_time == '2013-05-12 08:59:58'
+    assert ozone_data.levels == 11
+    assert ozone_data.profiles == 286368
+    assert ozone_data.min_pressure == None
+    assert ozone_data.max_pressure == None
+    assert ozone_data.ozone_count == 286368
+    assert ozone_data.sensor == 'OMIeff-adj'
+
+def test_ozone_ompslp_meta():
+    data = harvest(VALID_CONFIG_OZONE_OMPSLP)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_OMPSLP_DATA
+    assert ozone_data.obs_day == '2018-10-03 18:00:00'
+    assert ozone_data.min_date_time == '2018-10-03 15:34:02'
+    assert ozone_data.max_date_time == '2018-10-03 20:59:43'
+    assert ozone_data.levels == 56
+    assert ozone_data.profiles == 414
+    assert numpy.isclose(ozone_data.min_pressure, 2.568823)
+    assert numpy.isclose(ozone_data.max_pressure, 200.8631)
+    assert ozone_data.ozone_count == 23184
+    assert ozone_data.sensor == 'OMPS-LPoz-Vis'
+
+def test_ozone_ompsnm_meta():
+    data = harvest(VALID_CONFIG_OZONE_OMPSNM)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_OMPSNM_DATA
+    assert ozone_data.obs_day == '2012-12-03 00:00:00'
+    assert ozone_data.min_date_time == '2012-12-02 23:05:23'
+    assert ozone_data.max_date_time == '2012-12-03 02:59:57'
+    assert ozone_data.levels == 11
+    assert ozone_data.profiles == 34024
+    assert ozone_data.min_pressure == None
+    assert ozone_data.max_pressure == None
+    assert ozone_data.ozone_count == 34024
+    assert ozone_data.sensor == 'OMPSNM'
+
+def test_ozone_ompsnp_meta():
+    data = harvest(VALID_CONFIG_OZONE_OMPSNP)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_OMPSNP_DATA
+    assert ozone_data.obs_day == '2021-10-02 18:00:00'
+    assert ozone_data.min_date_time == '2021-10-02 15:00:06'
+    assert ozone_data.max_date_time == '2021-10-02 20:47:38'
+    assert ozone_data.levels == 21
+    assert ozone_data.profiles == 250
+    assert ozone_data.min_pressure == None
+    assert ozone_data.max_pressure == None
+    assert ozone_data.ozone_count == 5250
+    assert ozone_data.sensor == 'OMPSNP'


### PR DESCRIPTION
This PR adds a new harvester for ozone files stored in netcdf based on the structure of the two types of files currently used in NNJA made by NASA. This functionality will allow all ozone files to be inventoried through the observation-inventory-utils package. 

Test files have been uploaded to the score suite test data repository.