### PR TITLE
harvest GDAS-SOCA ocean diags RMS and ObsError

### DIFF
--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -17,7 +17,7 @@ from netCDF4 import Dataset
 from score_hv.config_base import ConfigInterface
 
 HARVESTER_NAME = 'soca_diags'
-VALID_STATISTICS = ('rms', 'RMS', 'mean', 'median', 'StdDev','minimum', 'maximum')
+VALID_STATISTICS = ('rms', 'RMS', 'mean', 'median', 'StdDev','minimum', 'maximum', 'n', 'nobs', 'count')
 
 """Variables of interest that come from the background forecast data.
 Commented out variables can be uncommented to generate gridcell weighted
@@ -266,7 +266,10 @@ class SOCADiagsHv(object):
                             if statistic == 'rms' or statistic == 'RMS':
                                 value = np.sqrt(np.ma.mean(masked_var**2))
                            
-                            if statistic == 'mean':
+                            elif statistic == 'n' or statistic == 'nobs' or statistic == 'count':
+                                value = np.ma.count(masked_var)
+                            
+                            elif statistic == 'mean':
                                 value = np.ma.mean(masked_var)
                                
                             elif statistic == 'median':
@@ -291,7 +294,7 @@ class SOCADiagsHv(object):
                                                   longname,
                                                   units,
                                                   statistic,
-                                                  float(value),
+                                                  value,
                                                   filetime_dt,
                                                   file_region))
             dataset.close()               

--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -212,7 +212,7 @@ class SOCADiagsHv(object):
      
     def get_data(self):
         depths = self.config.depths
-        groups_wanted = ['ObsValue','oman','ombg']
+        groups_wanted = ('ObsValue','oman','ombg', 'ObsError')
         units = None
         for filename in self.config.harvest_filenames:
             harvested_data = list()
@@ -225,10 +225,8 @@ class SOCADiagsHv(object):
             """The information about the file from the 
             file name.
             """
-            variable = filename_info['variable_type']  
             filetime_str = filename_info['datetime']
-            dt_obj = dt.strptime(filetime_str, "%Y%m%d%H")
-            filetime = dt_obj.strftime("%Y-%m-%d %H:%M:%S")
+            filetime_dt = dt.strptime(filetime_str, "%Y%m%d%H")
             sensor = filename_info['sensor']
             file_region = filename_info['region']
             satellite = filename_info['satellite']
@@ -250,8 +248,8 @@ class SOCADiagsHv(object):
                         if "units" in var.ncattrs():
                             units = str(var.getncattr("units"))
    
-                        if '_FillValue' in groupvalue_variable.ncattrs():
-                            fill_value = groupvalue_variable.getncattr('_FillValue')
+                        if '_FillValue' in var.ncattrs():
+                            fill_value = var.getncattr('_FillValue')
                             masked_var = np.ma.masked_where(var[:] == fill_value, 
                                                             var[:])
                         else:   
@@ -288,13 +286,13 @@ class SOCADiagsHv(object):
                                                   sensor,
                                                   satellite,
                                                   level,
-                                                  variable,
+                                                  var_name,
                                                   group,
                                                   longname,
                                                   units,
                                                   statistic,
                                                   float(value),
-                                                  filetime,
+                                                  filetime_dt,
                                                   file_region))
             dataset.close()               
             return(harvested_data)

--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -17,7 +17,7 @@ from netCDF4 import Dataset
 from score_hv.config_base import ConfigInterface
 
 HARVESTER_NAME = 'soca_diags'
-VALID_STATISTICS = ('mean', 'median', 'StdDev','minimum', 'maximum')
+VALID_STATISTICS = ('rms', 'RMS', 'mean', 'median', 'StdDev','minimum', 'maximum')
 
 """Variables of interest that come from the background forecast data.
 Commented out variables can be uncommented to generate gridcell weighted
@@ -29,8 +29,12 @@ VALID_VARIABLES  =  ('sst', #sea surface temperature
                      'waterTemperature',
                      'seaSurfaceSalinity',
                      'seaSurfaceTemperature',
+                     ''
                     )
-HarvestedData = namedtuple('HarvestedData', ['filenames',
+HarvestedData = namedtuple(
+    #TODO: implement depths as harvested coordinate array
+    'HarvestedData',
+                                            ['filenames',
                                              'sensor',
                                              'satellite',
                                              'level',
@@ -62,36 +66,43 @@ def parse_filename(filename):
       """
     base = os.path.basename(filename)
     try:
-       name_part, datetime_part, ext = base.rsplit('.', 2)
+        name_part, datetime_part, ext = base.rsplit('.', 2)
     except ValueError:
-       raise ValueError(f"Filename format unexpected: {filename}")
+        raise ValueError(f"Filename format unexpected: {filename}")
 
     parts = name_part.split('_')
     # Initialize dictionary with default values
-    filename_info = {
-              'variable_type': parts[0],
-              'sensor':  parts[1],
-    }        
-    if filename_info['variable_type'] == 'insitu':
-       filename_info['sensor'] = None
-
-    filename_info['datetime'] = datetime_part 
-    filename_info['region'] = 'global'
-    filename_info['satellite'] = None
-    filename_info['level'] = None
-    if len(parts) == 3:
-       if filename_info['variable_type'] == 'insitu':
-          filename_info['satellite'] = parts[2]
-       else:
-          filename_info['region'] = parts[2]
-    elif len(parts) == 4:
-       filename_info['satellite'] = parts[2]
-       filename_info['level'] = parts[3]
-    elif len(parts) == 5:
-       filename_info['level'] = parts[3]
-       filename_info['region'] = parts[4]
+    filename_info = {'datetime': datetime_part,
+                     'region': 'global',
+                     'satellite': None,
+                     'level': None,
+                     'variable_type': parts[0],
+                     'data_source': None,
+                     'sensor': parts[1]}
+    
+    if parts[0] == 'wod' and parts[1] == 't':
+        # source is World Ocean Data
+        filename_info['data_source'] = parts[0]
+        filename_info['variable_type'] = parts[1]
+        filename_info['sensor'] = parts[2]
+    elif parts[0] == 'insitu':
+        # defaults for insitu data
+        filename_info['sensor'] = parts[2]
+    elif parts[0] == 'icec':
+        filename_info['sensor'] = parts[1]
+        filename_info['region'] = parts[2]
+    elif parts[0] == 'sst':
+        filename_info['sensor'] = parts[1]
+        filename_info['satellite'] = parts[2]
+        filename_info['level'] = parts[3]
+    
+    elif False and len(parts) == 5:
+        # disabled until further information provided and boolean made more specific
+        filename_info['level'] = parts[3]
+        filename_info['region'] = parts[4]
+    
     else:
-       raise ValueError(f"Unexpected number of parts in filename: {filename}")
+        raise ValueError(f"ocean diags file not supported in score-hv: {filename}")
 
     return filename_info
 
@@ -106,21 +117,21 @@ def read_MetaData_group(dataset):
                 from the MetadData group.
        """
     if 'MetaData' not in dataset.groups:
-       latitude = None
-       longitude = None
+        latitude = None
+        longitude = None
     else: 
-       metadata_group = dataset.groups['MetaData'] 
-       if 'latitude' in metadata_group.variables:
-          latitude = metadata_group['latitude'][:]
-       else:
-          latitude = None 
-          print("'latitude' not found in metadata_vars")
+        metadata_group = dataset.groups['MetaData'] 
+        if 'latitude' in metadata_group.variables:
+            latitude = metadata_group['latitude'][:]
+        else:
+            latitude = None 
+            print("'latitude' not found in metadata_vars")
 
-       if 'longitude' in metadata_group.variables:
-          longitude = metadata_group['longitude'][:]
-       else:
-          longitude = None 
-          print("'longitude' not found in metadata_vars")
+        if 'longitude' in metadata_group.variables:
+            longitude = metadata_group['longitude'][:]
+        else:
+           longitude = None 
+           print("'longitude' not found in metadata_vars")
 
     return(latitude,longitude)
 
@@ -207,14 +218,13 @@ class SOCADiagsHv(object):
             harvested_data = list()
             filename_info = parse_filename(filename)
             try:
-               dataset = netCDF4.Dataset(filename, 'r')
+                dataset = netCDF4.Dataset(filename, 'r')
             except Exception as e: 
-               raise OSError (f"Failed to open NetCDF file {filename}: {e}")
+                raise OSError (f"Failed to open NetCDF file {filename}: {e}")
 
+            """The information about the file from the 
+            file name.
             """
-              The information about the file from the 
-              file name.
-              """
             variable = filename_info['variable_type']  
             filetime_str = filename_info['datetime']
             dt_obj = dt.strptime(filetime_str, "%Y%m%d%H")
@@ -225,71 +235,66 @@ class SOCADiagsHv(object):
             level = filename_info['level']
             latitude,longitude = read_MetaData_group(dataset)
             
+            """We can now loop through the list of wanted groups.
+            We get the values from the wanted groups and the FillValue.
             """
-              We can now loop through the list of wanted groups.
-              We get the values from the wanted groups and the FillValue.
-              """
             for group in groups_wanted:
                 if group not in dataset.groups:
-                   raise ValueError(f"{group} is not in dataset.groups: {dataset.groups}")   
+                    raise ValueError(f"{group} is not in dataset.groups: {dataset.groups}")   
                 else:     
-                   requested_group = dataset.groups[group]
-                   group_name = group
-                   num_variables = len(requested_group.variables)
-                   for var_name in requested_group.variables:
-                       variable = var_name
-                       var = requested_group.variables[var_name]
-                       longname = var_name 
-                       if "units" in var.ncattrs():
-                          units = str(var.getncattr("units"))
+                    requested_group = dataset.groups[group]
+                    num_variables = len(requested_group.variables)
+                    for var_name in requested_group.variables:
+                        var = requested_group.variables[var_name]
+                        longname = var_name 
+                        if "units" in var.ncattrs():
+                            units = str(var.getncattr("units"))
    
-                       groupvalue_variable = requested_group.variables[var_name]
-
-                       if '_FillValue' in groupvalue_variable.ncattrs():
-                          fill_value = groupvalue_variable.getncattr('_FillValue')
-                          var_values = np.ma.masked_where(groupvalue_variable[:] == fill_value,groupvalue_variable[:])
-                       else:   
-                          var_values =  np.ma.array(groupvalue_variable[:])
-                       """
-                         Mask out the nans in place.
-                         """
-                       np.ma.masked_where(var_values == np.nan,var_values,copy=False)
+                        if '_FillValue' in groupvalue_variable.ncattrs():
+                            fill_value = groupvalue_variable.getncattr('_FillValue')
+                            masked_var = np.ma.masked_where(var[:] == fill_value, 
+                                                            var[:])
+                        else:   
+                            masked_var =  np.ma.array(var[:])
+                        """
+                        Mask out the nans in place.
+                        """
+                        np.ma.masked_where(masked_var == np.nan, masked_var,
+                                          copy=False)
                        
-                       """
-                          Calculate the requested statistics. Our var_values arrays are 
-                          all of type <class 'numpy.ndarray'>.  We have used the fill_value
-                          to put np.nan's in the for all values to to the fill_values so we 
-                          can calculate the statistics.
-                          """
-                       for j, statistic in enumerate(self.config.get_stats()):
-                           group = group_name
-                           if statistic == 'mean':
-                               value = np.ma.mean(var_values)
-                               
-                           elif statistic == 'median':
-                               value = np.ma.median(var_values)
-                                
-                           elif statistic == 'StdDev':
-                               value = np.ma.std(var_values)
-                               
-                           elif statistic == 'minimum':
-                               value = np.ma.min(var_values)
+                        # Calculate the requested statistics
+                        for k, statistic in enumerate(self.config.get_stats()):
                            
-                           elif statistic == 'maximum':
-                               value = np.ma.max(var_values)
+                            if statistic == 'rms' or statistic == 'RMS':
+                                value = np.sqrt(np.ma.mean(masked_var**2))
+                           
+                            if statistic == 'mean':
+                                value = np.ma.mean(masked_var)
+                               
+                            elif statistic == 'median':
+                                value = np.ma.median(masked_var)
                                 
-                           harvested_data.append(HarvestedData(
-                                                 filename,
-                                                 sensor,
-                                                 satellite,
-                                                 level,
-                                                 variable,
-                                                 group,
-                                                 longname,
-                                                 units,
-                                                 statistic,
-                                                 np.float32(value),
-                                                 filetime,
-                                                 file_region))
+                            elif statistic == 'StdDev':
+                                value = np.ma.std(masked_var)
+                               
+                            elif statistic == 'minimum':
+                                value = np.ma.min(masked_var)
+                           
+                            elif statistic == 'maximum':
+                                value = np.ma.max(masked_var)
+                                
+                            harvested_data.append(HarvestedData(
+                                                  filename,
+                                                  sensor,
+                                                  satellite,
+                                                  level,
+                                                  variable,
+                                                  group,
+                                                  longname,
+                                                  units,
+                                                  statistic,
+                                                  float(value),
+                                                  filetime,
+                                                  file_region))
             dataset.close()               
             return(harvested_data)

--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -29,7 +29,6 @@ VALID_VARIABLES  =  ('sst', #sea surface temperature
                      'waterTemperature',
                      'seaSurfaceSalinity',
                      'seaSurfaceTemperature',
-                     ''
                     )
 HarvestedData = namedtuple(
     #TODO: implement depths as harvested coordinate array

--- a/src/score_hv/harvesters/soca_diags.py
+++ b/src/score_hv/harvesters/soca_diags.py
@@ -94,6 +94,11 @@ def parse_filename(filename):
         filename_info['sensor'] = parts[1]
         filename_info['satellite'] = parts[2]
         filename_info['level'] = parts[3]
+    elif parts[0] == 'icoads':
+        # source is ICOADS
+        filename_info['data_source'] = parts[0]
+        filename_info['variable_type'] = parts[1]
+        filename_info['sensor'] = 'misc_icoads'
     
     elif False and len(parts) == 5:
         # disabled until further information provided and boolean made more specific

--- a/tests/test_harvester_soca_wod_water_temperature.py
+++ b/tests/test_harvester_soca_wod_water_temperature.py
@@ -12,7 +12,7 @@ TEST_DATA_FILE_NAMES = [
                        ]
 
 PYTEST_CALLING_DIR = Path(__file__).parent.resolve()
-TEST_DATA_PATH = os.path.join(PYTEST_CALLING_DIR, 'data_dev')
+TEST_DATA_PATH = os.path.join(PYTEST_CALLING_DIR, 'data')
 SOCA_PATH = [os.path.join(TEST_DATA_PATH,
                          file_name) for file_name in TEST_DATA_FILE_NAMES]
 

--- a/tests/test_harvester_soca_wod_water_temperature.py
+++ b/tests/test_harvester_soca_wod_water_temperature.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import os
+from pathlib import Path
+from datetime import datetime
+
+from score_hv import hv_registry
+from score_hv.harvester_base import harvest
+
+TEST_DATA_FILE_NAMES = [
+                        'wod_t_ctd.1979010200.nc4'
+                       ]
+
+PYTEST_CALLING_DIR = Path(__file__).parent.resolve()
+TEST_DATA_PATH = os.path.join(PYTEST_CALLING_DIR, 'data_dev')
+SOCA_PATH = [os.path.join(TEST_DATA_PATH,
+                         file_name) for file_name in TEST_DATA_FILE_NAMES]
+
+VALID_CONFIG_DICT = {'harvester_name': hv_registry.SOCA_DIAGS,
+                     'filenames' : SOCA_PATH,
+                     'statistics': ['rms', 'mean'],
+                     'variables': ['waterTemperature'],
+                     }
+
+def test_waterTemperature(tolerance=0.001):
+    data1 = harvest(VALID_CONFIG_DICT)
+    dt = datetime.strptime('1979010200', "%Y%m%d%H")
+    
+    ombg_exists = False
+    obs_error_exists = False
+    for item in data1:
+        assert item.filenames.split('/')[-1] == 'wod_t_ctd.1979010200.nc4'
+        assert item.sensor == 'ctd'
+        assert item.satellite == None
+        assert item.level == None
+        assert item.variables == 'waterTemperature'
+        assert item.statistics == 'rms' or item.statistics == 'mean'
+        assert item.filetime == dt
+        assert item.file_region == 'global'
+        
+        if item.group == 'ombg' and item.statistics == 'rms':
+            ombg_exists = True
+            offline_rms = 1.642326233143017
+            assert item.value <= (1+tolerance) * offline_rms
+            assert item.value >= (1-tolerance) * offline_rms
+            
+        if item.group == 'ObsError' and item.statistics == 'mean':
+            obs_error_exists = True
+            offline_mean = 0.5
+            assert item.value <= (1+tolerance) * offline_mean
+            assert item.value >= (1-tolerance) * offline_mean
+            
+    assert ombg_exists
+    assert obs_error_exists
+
+def main():
+    test_waterTemperature()
+
+if __name__=='__main__':
+    main()

--- a/tests/test_harvester_soca_wod_water_temperature.py
+++ b/tests/test_harvester_soca_wod_water_temperature.py
@@ -18,7 +18,7 @@ SOCA_PATH = [os.path.join(TEST_DATA_PATH,
 
 VALID_CONFIG_DICT = {'harvester_name': hv_registry.SOCA_DIAGS,
                      'filenames' : SOCA_PATH,
-                     'statistics': ['rms', 'mean'],
+                     'statistics': ['rms', 'mean', 'count'],
                      'variables': ['waterTemperature'],
                      }
 
@@ -34,7 +34,7 @@ def test_waterTemperature(tolerance=0.001):
         assert item.satellite == None
         assert item.level == None
         assert item.variables == 'waterTemperature'
-        assert item.statistics == 'rms' or item.statistics == 'mean'
+        assert item.statistics == 'rms' or item.statistics == 'mean' or item.statistics == 'count'
         assert item.filetime == dt
         assert item.file_region == 'global'
         

--- a/tests/test_icec_amsr2_north.py
+++ b/tests/test_icec_amsr2_north.py
@@ -34,6 +34,9 @@ VALID_CONFIG_DICT = {'harvester_name': hv_registry.SOCA_DIAGS,
                      'variables': ['icec'],
                      }
 
+def groups_supported(group_list = ('ObsValue','oman','ombg', 'ObsError')):
+    return group_list
+
 def test_soca_harvester():
     data1 = harvest(VALID_CONFIG_DICT)
     assert type(data1) is list
@@ -51,22 +54,14 @@ def test_verify_datetime():
     data1 = harvest(VALID_CONFIG_DICT) 
     date_str = "2021070300"
     date_obj = datetime.strptime(date_str, "%Y%m%d%H")
-    filetime_str = data1[0].filetime
-    filetime_dt = datetime.strptime(filetime_str, "%Y-%m-%d %H:%M:%S")
-    assert date_obj == filetime_dt 
+    for item in data1:
+        assert date_obj == item.filetime
 
 def test_verify_groups():
     data1 = harvest(VALID_CONFIG_DICT)
-    groups_wanted = ['ObsValue', 'oman', 'ombg']
+    groups_wanted = groups_supported()
     for data in data1:
         assert data.group in groups_wanted, f"Unexpected group: {data.group}"
-
-def get_harvested_statistic_value(statistic):
-    data1 = harvest(VALID_CONFIG_DICT)
-    harvested_data = {
-        data.group: data.value for data in data1 if data.statistics == statistic
-    }
-    return harvested_data    
 
 def test_verify_group_mean_values(tolerance=0.001):
     """
@@ -78,7 +73,7 @@ def test_verify_group_mean_values(tolerance=0.001):
       """
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_means = [0.5933418,0.06660749,0.1327579]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     group_index = 0
     # Filter out only the data that has the "mean" statistic
     harvested_data = [data for data in data1 if data.statistics == 'mean']
@@ -88,16 +83,19 @@ def test_verify_group_mean_values(tolerance=0.001):
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_mean = data.value
-        calculated_value = calculated_means[group_index]
-        # Verify that the harvested mean is within tolerance of the calculated mean
-        assert abs(harvested_mean - calculated_value) <= tolerance, f"Mean value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_mean = data.value
+            calculated_value = calculated_means[group_index]
+            # Verify that the harvested mean is within tolerance of the calculated mean
+            assert abs(harvested_mean - calculated_value) <= tolerance, f"Mean value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
        
 def test_verify_group_median_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_medians = [0.949999988079071,0.01528690755367279,0.043333768844604485]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     group_index = 0
     harvested_data = [data for data in data1 if data.statistics == 'median']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
@@ -105,16 +103,20 @@ def test_verify_group_median_values(tolerance=0.001):
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_medians = data.value
-        calculated_value = calculated_medians[group_index]
-        # Verify that the harvested mean is within tolerance of the calculated median 
-        assert abs(harvested_medians - calculated_value) <= tolerance, f"Median value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_medians = data.value
+            calculated_value = calculated_medians[group_index]
+            # Verify that the harvested mean is within tolerance of the calculated median 
+            assert abs(harvested_medians - calculated_value) <= tolerance, f"Median value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
+            
 
 def test_verify_group_StdDev_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_StdDevs = [0.46483881994362,0.15594015101052516,0.20401885665594757]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     group_index = 0
     harvested_data = [data for data in data1 if data.statistics == 'StdDev']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
@@ -122,10 +124,13 @@ def test_verify_group_StdDev_values(tolerance=0.001):
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_StdDevs = data.value
-        calculated_value = calculated_StdDevs[group_index]
-        assert abs(harvested_StdDevs - calculated_value) <= tolerance, f"Standard Deviation value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_StdDevs = data.value
+            calculated_value = calculated_StdDevs[group_index]
+            assert abs(harvested_StdDevs - calculated_value) <= tolerance, f"Standard Deviation value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def test_verify_group_minimum_values(tolerance=0.001):
     """
@@ -137,7 +142,7 @@ def test_verify_group_minimum_values(tolerance=0.001):
       """
     data1 = harvest(VALID_CONFIG_DICT)
     calculated_minimums = [0.0,-0.8637589812278748,-0.8629218339920045]
-    groups_wanted = ['ObsValue','oman','ombg']
+    groups_wanted = groups_supported()
     group_index = 0
     harvested_data = [data for data in data1 if data.statistics == 'minimum']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
@@ -145,10 +150,13 @@ def test_verify_group_minimum_values(tolerance=0.001):
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_minimum = data.value
-        calculated_value = calculated_minimums[group_index]
-        assert abs(harvested_minimum - calculated_value) <= tolerance, f"Minimum value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_minimum = data.value
+            calculated_value = calculated_minimums[group_index]
+            assert abs(harvested_minimum - calculated_value) <= tolerance, f"Minimum value mismatch for {group_name}"
+            group_index += 1
+    
+    assert group_index == 3
 
 def test_verify_group_maximum_values(tolerance=0.001):
     """
@@ -160,7 +168,7 @@ def test_verify_group_maximum_values(tolerance=0.001):
       """
     data1 = harvest(VALID_CONFIG_DICT)
     calculated_maximums = [1.0,1.0,1.0]
-    groups_wanted = ['ObsValue','oman','ombg']
+    groups_wanted = groups_supported()
     group_index = 0
     harvested_data = [data for data in data1 if data.statistics == 'maximum']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
@@ -168,10 +176,13 @@ def test_verify_group_maximum_values(tolerance=0.001):
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_maximum = data.value
-        calculated_value = calculated_maximums[group_index]
-        assert abs(harvested_maximum - calculated_value) <= tolerance, f" Maximum value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_maximum = data.value
+            calculated_value = calculated_maximums[group_index]
+            assert abs(harvested_maximum - calculated_value) <= tolerance, f" Maximum value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def main():
     test_soca_harvester()

--- a/tests/test_insitu_profile.py
+++ b/tests/test_insitu_profile.py
@@ -46,21 +46,20 @@ def test_verify_filename_components():
     for item in data1:
         if item.variables not in expected_variable_names:
            raise ValueError(f"Error: {item.variable} is not in the expected variable list.") 
-        assert item.sensor == None   
-        assert item.satellite == 'argo'
-        assert item.level == None   
+        assert item.sensor == 'argo'   
+        assert item.satellite == None
+        assert item.level == None
 
 def test_verify_datetime():
     data1 = harvest(VALID_CONFIG_DICT) 
     date_str = "2021070300"
     date_obj = datetime.strptime(date_str, "%Y%m%d%H")
-    filetime_str = data1[0].filetime
-    filetime_dt = datetime.strptime(filetime_str, "%Y-%m-%d %H:%M:%S")
-    assert date_obj == filetime_dt 
+    for item in data1:
+        assert date_obj == item.filetime
 
 def test_verify_groups():
     data1 = harvest(VALID_CONFIG_DICT)
-    groups_wanted = ['ObsValue', 'oman', 'ombg']
+    groups_wanted = ('ObsValue', 'oman', 'ombg', 'ObsError')
     for data in data1:
         assert data.group in groups_wanted, f"Unexpected group: {data.group}"
    

--- a/tests/test_insitu_surface.py
+++ b/tests/test_insitu_surface.py
@@ -48,8 +48,8 @@ def test_verify_filename_components():
     for item in data1:
         if item.variables not in expected_variable_names:
            raise ValueError(f"Error: {item.variables} is not in the expected variable list.")  
-        assert item.sensor == None   
-        assert item.satellite == 'trkob'
+        assert item.sensor == 'trkob' 
+        assert item.satellite == None
         assert item.level == None
         assert item.file_region == 'global'
 
@@ -57,9 +57,8 @@ def test_verify_datetime():
     data1 = harvest(VALID_CONFIG_DICT)
     date_str = "2021070300"
     date_obj = datetime.strptime(date_str, "%Y%m%d%H")
-    filetime_str = data1[0].filetime
-    filetime_dt = datetime.strptime(filetime_str, "%Y-%m-%d %H:%M:%S")
-    assert date_obj == filetime_dt 
+    for item in data1:
+        assert date_obj == item.filetime
 
 def test_verify_group_mean_values(tolerance=.001):
     data1 = harvest(VALID_CONFIG_DICT) 

--- a/tests/test_sst_viirs_n20_l3u.py
+++ b/tests/test_sst_viirs_n20_l3u.py
@@ -34,6 +34,9 @@ VALID_CONFIG_DICT = {'harvester_name': hv_registry.SOCA_DIAGS,
                      'variables': ['sst'],
                      }
 
+def groups_supported(group_list = ('ObsValue','oman','ombg', 'ObsError')):
+    return group_list
+
 def test_soca_harvester():
     data1 = harvest(VALID_CONFIG_DICT)
     assert type(data1) is list
@@ -52,13 +55,12 @@ def test_verify_datetime():
     data1 = harvest(VALID_CONFIG_DICT) 
     date_str = "2021070300"
     date_obj = datetime.strptime(date_str, "%Y%m%d%H")
-    filetime_str = data1[0].filetime
-    filetime_dt = datetime.strptime(filetime_str, "%Y-%m-%d %H:%M:%S")
-    assert date_obj == filetime_dt 
+    for item in data1:
+        assert date_obj == item.filetime
 
 def test_verify_groups():
     data1 = harvest(VALID_CONFIG_DICT)
-    groups_wanted = ['ObsValue', 'oman', 'ombg']
+    groups_wanted = groups_supported()
     for data in data1:
         assert data.group in groups_wanted, f"Unexpected group: {data.group}"
 
@@ -68,79 +70,94 @@ def test_verify_group_mean_values(tolerance=0.001):
       """
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_means = [18.924038657133483,0.06212510113054594,0.07588130216644204]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     harvested_data = [data for data in data1 if data.statistics == 'mean']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
    
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_mean = data.value
-        calculated_value = calculated_means[group_index]
-        # Verify that the harvested mean is within tolerance of the calculated mean
-        assert abs(harvested_mean - calculated_value) <= tolerance, f"Mean value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_mean = data.value
+            calculated_value = calculated_means[group_index]
+            # Verify that the harvested mean is within tolerance of the calculated mean
+            assert abs(harvested_mean - calculated_value) <= tolerance, f"Mean value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
        
 def test_verify_group_median_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_medians = [22.409034729003906,0.029189025983214375,0.055334743112325675]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     harvested_data = [data for data in data1 if data.statistics == 'median']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
    
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_medians = data.value
-        calculated_value = calculated_medians[group_index]
-        # Verify that the harvested mean is within tolerance of the calculated median 
-        assert abs(harvested_medians - calculated_value) <= tolerance, f"Median value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_medians = data.value
+            calculated_value = calculated_medians[group_index]
+            # Verify that the harvested mean is within tolerance of the calculated median 
+            assert abs(harvested_medians - calculated_value) <= tolerance, f"Median value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def test_verify_group_StdDev_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT) 
     calculated_StdDevs = [9.234388236283511,0.43633542496370253,0.4974935575667632]
-    groups_wanted = ['ObsValue','oman','ombg'] 
+    groups_wanted = groups_supported() 
     harvested_data = [data for data in data1 if data.statistics == 'StdDev']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
     
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_StdDevs = data.value
-        calculated_value = calculated_StdDevs[group_index]
-        assert abs(harvested_StdDevs - calculated_value) <= tolerance, f"Standard Deviation value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_StdDevs = data.value
+            calculated_value = calculated_StdDevs[group_index]
+            assert abs(harvested_StdDevs - calculated_value) <= tolerance, f"Standard Deviation value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def test_verify_group_minimum_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT)
     calculated_minimums = [-2.123818159103393,-6.02739143371582,-6.222834587097168]
-    groups_wanted = ['ObsValue','oman','ombg']
+    groups_wanted = groups_supported()
     harvested_data = [data for data in data1 if data.statistics == 'minimum']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."
     
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_minimum = data.value
-        calculated_value = calculated_minimums[group_index]
-        assert abs(harvested_minimum - calculated_value) <= tolerance, f"Minimum value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_minimum = data.value
+            calculated_value = calculated_minimums[group_index]
+            assert abs(harvested_minimum - calculated_value) <= tolerance, f"Minimum value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def test_verify_group_maximum_values(tolerance=0.001):
     data1 = harvest(VALID_CONFIG_DICT)
     calculated_maximums = [34.480560302734375,11.538920402526855,11.55988597869873]
-    groups_wanted = ['ObsValue','oman','ombg']
+    groups_wanted = groups_supported()
     harvested_data = [data for data in data1 if data.statistics == 'maximum']
     assert len(harvested_data) == len(groups_wanted), "Error: Mismatch between expected groups and harvested data."    
 
     group_index = 0
     for data in harvested_data:
         group_name = data.group
-        harvested_maximum = data.value
-        calculated_value = calculated_maximums[group_index]
-        assert abs(harvested_maximum - calculated_value) <= tolerance, f" Maximum value mismatch for {group_name}"
-        group_index += 1
+        if group_name == 'ObsValue' or group_name == 'oman' or group_name == 'ombg':
+            harvested_maximum = data.value
+            calculated_value = calculated_maximums[group_index]
+            assert abs(harvested_maximum - calculated_value) <= tolerance, f" Maximum value mismatch for {group_name}"
+            group_index += 1
+            
+    assert group_index == 3
 
 def main():
     test_soca_harvester()


### PR DESCRIPTION
migrated from https://github.com/NOAA-PSL/score-hv/pull/82:

Support for harvesting observation errors and calculating RMS from GDAS-SOCA ocean diag files. This feature adds these capabilities to the existing soca_diags harvester and amends the corresponding unit tests without modifying previous hard-coded test values. Specific changes include:

Rework of the filename parser in the soca_diags harvester
four space indentation corrections
minor variable definition redundancy clean up
additional unit test file for waterTemperature, which tests calculations for mean ObsError and waterTemperature RMSE (from ombg)
corrections of existing unit tests w.r.t meta-data, e.g., satellite versus sensor info
support for ObsError to be included in the list of supported groups without disrupting existing unit tests for ObsValue, ombg, and oman
These changes have been tested successfully against the existing (develop branch) unit tests and against the upgraded tests provided in this PR.

