### PR TITLE
handle empty files from nasa ozone streams

### DIFF
--- a/src/score_hv/harvesters/ozone_meta_netcdf.py
+++ b/src/score_hv/harvesters/ozone_meta_netcdf.py
@@ -90,7 +90,7 @@ class OzoneMetaHv:
         harvested_data = []
         dataset = Dataset(self.config.harvest_filename, 'r')
 
-
+        ozone = None
         # --- Get ozone data (2D: nprofiles x nlevs) ---
         if 'ozone' in dataset.variables:
             ozone = dataset.variables['ozone'][:]  # shape: (nprofiles, nlevs)
@@ -100,6 +100,28 @@ class OzoneMetaHv:
         if 'toz' in dataset.variables:
             ozone = dataset.variables['toz'][:]  # shape: (nrec)
             valid_ozone_count = np.count_nonzero(~np.isnan(ozone))
+
+        filename_parsed = parse_filename(self.config.harvest_filename) 
+        sensor = filename_parsed['sensor']
+        filename = filename_parsed['filename']
+        obs_day = filename_parsed['formatted_datetime_str']
+
+        if ozone is None: # file is empty 
+            harvested_data.append(
+                HarvestedData(
+                    filename,
+                    obs_day,
+                    None,
+                    None,
+                    0,
+                    0,
+                    None, 
+                    None,
+                    0,
+                    sensor, 
+                )
+            ) 
+            return harvested_data
 
         # --- Read profile-level datetime components ---
         year   = np.ma.filled(dataset.variables['yy'][:], np.nan)
@@ -147,11 +169,6 @@ class OzoneMetaHv:
             profiles = len(dataset.dimensions['nrec'])
         elif 'nprofiles' in dataset.dimensions:
             profiles = len(dataset.dimensions['nprofiles'])
-
-        filename_parsed = parse_filename(self.config.harvest_filename) 
-        sensor = filename_parsed['sensor']
-        filename = filename_parsed['filename']
-        obs_day = filename_parsed['formatted_datetime_str']
 
         harvested_data.append(
             HarvestedData(

--- a/tests/test_harvester_ozone_meta_netcdf.py
+++ b/tests/test_harvester_ozone_meta_netcdf.py
@@ -15,12 +15,14 @@ OZONE_OMI_EFF_DATA = 'OMIeff-adj.20130512_06z.nc'
 OZONE_OMPSLP_DATA = 'OMPS-LPoz-Vis.20181003_18z.nc'
 OZONE_OMPSNM_DATA = 'OMPSNM.20121203_00z.nc'
 OZONE_OMPSNP_DATA = 'OMPSNP.20211002_18z.nc'
+OZONE_OMPSNP_ZERO_DATA = 'OMPSNP.20130106_06z.nc'
 
 file_path_ozone_mls_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_MLS_DATA)
 file_path_ozone_omi_eff_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMI_EFF_DATA)
 file_path_ozone_omsplp_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSLP_DATA)
 file_path_ozone_ompsnm_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSNM_DATA)
 file_path_ozone_ompsnp_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSNP_DATA)
+file_path_ozone_ompsnp_zero_data = os.path.join(PYTEST_CALLING_DIR, DATA_DIR, OZONE_OMPSNP_ZERO_DATA)
 
 VALID_CONFIG_OZONE_MLS = {
     'harvester_name': hv_registry.OZONE_META_NETCDF,
@@ -45,6 +47,11 @@ VALID_CONFIG_OZONE_OMPSNM = {
 VALID_CONFIG_OZONE_OMPSNP = {
     'harvester_name': hv_registry.OZONE_META_NETCDF,
     'filename': file_path_ozone_ompsnp_data
+}
+
+VALID_CONFIG_OZONE_OMPSNP_ZERO = {
+    'harvester_name': hv_registry.OZONE_META_NETCDF,
+    'filename': file_path_ozone_ompsnp_zero_data
 }
 
 def test_ozone_mls_meta():
@@ -115,4 +122,18 @@ def test_ozone_ompsnp_meta():
     assert ozone_data.min_pressure == None
     assert ozone_data.max_pressure == None
     assert ozone_data.ozone_count == 5250
+    assert ozone_data.sensor == 'OMPSNP'
+
+def test_ozone_ompsnp_zero_meta():
+    data = harvest(VALID_CONFIG_OZONE_OMPSNP_ZERO)
+    ozone_data = data[0]
+    assert ozone_data.filename == OZONE_OMPSNP_ZERO_DATA
+    assert ozone_data.obs_day == '2013-01-06 06:00:00'
+    assert ozone_data.min_date_time == None
+    assert ozone_data.max_date_time == None
+    assert ozone_data.levels == 0
+    assert ozone_data.profiles == 0
+    assert ozone_data.min_pressure == None
+    assert ozone_data.max_pressure == None
+    assert ozone_data.ozone_count == 0
     assert ozone_data.sensor == 'OMPSNP'


### PR DESCRIPTION
This is bug fix to return a harvested data of 0 content when a file that exists but contains no data is passed to harvester. The 0s are the correct metadata for the file and will allow downstream users to handle data accordingly such as in the obs inventory. 

A test file of this format has been uploaded and a new test included and passing. 