### PR TITLE
Update ioda meta netcdf harvester for additional formatting options

### DIFF
--- a/src/score_hv/harvesters/ioda_meta_netcdf.py
+++ b/src/score_hv/harvesters/ioda_meta_netcdf.py
@@ -133,6 +133,12 @@ class IodaMetaHv:
                 num_locs = len(num_locs_var)
             else:
                 num_locs = num_locs_var.size
+        elif num_locs is None and 'Location' in dataset.variables:
+            num_locs_var = dataset.variables['Location'][:]
+            if num_locs_var.size == 1:
+                num_locs = len(num_locs_var)
+            else:
+                num_locs = num_locs_var.size
 
         valid_value_counts = {}
         if 'ObsValue' in dataset.groups:
@@ -243,7 +249,7 @@ def parse_filename(file_path):
     filename = os.path.basename(file_path)
     
     # Regular expression to match the filename pattern
-    pattern = r'.*?(\d{8})\.T(\d{6})Z?\.ioda(v\d+)\b.*\.nc$'
+    pattern = r'.*?(\d{8})\.T(\d{2,6})Z?\.ioda(v\d+)\b.*\.nc$'
     
     match = re.match(pattern, filename)
     if match:
@@ -251,9 +257,17 @@ def parse_filename(file_path):
         date_str = match.group(1)
         time_str = match.group(2)
         ioda_version = match.group(3)
+
+        # Determine the correct time format based on length
+        if len(time_str) == 2:
+            time_format = "%H"
+        elif len(time_str) == 6:
+            time_format = "%H%M%S"
+        else:
+            raise ValueError(f"Unexpected time format length: {len(time_str)} for filename: {filename}")
         
         # Combine date and time into a datetime object
-        dt = datetime.strptime(f"{date_str}{time_str}", "%Y%m%d%H%M%S")
+        dt = datetime.strptime(f"{date_str}{time_str}", f"%Y%m%d{time_format}")
         
         # Format the datetime string as 'YYYY-MM-DD HH:MM:SS'
         formatted_datetime_str = format_datetime_string(dt)

--- a/tests/test_harvester_ioda_meta_netcdf.py
+++ b/tests/test_harvester_ioda_meta_netcdf.py
@@ -17,6 +17,7 @@ from score_hv.harvesters.ioda_meta_netcdf import IodaMetaCfg
 
 IODA_SST_DATA = 'sst.nesdis.avhrr_l3u_noaa19.20150820.T120000Z.iodav3.nc'
 IODA_SST_N7_DATA = 'nesdis.avhrr_noaa07.sst.19810901.T030000Z.iodav2.so0p25.nc'
+IODA_SST_NGGODAS_DATA = 'sst.ESACCI20cm.avhrr.19970105.T00Z.iodav3.nc'
 IODA_INSITU_DATA = 'wod.ncei.insitu.20090605.T000000Z.iodav2.nc'
 IODA_INSITU_V3_DATA = 'wod.ncei_insitu.20090605.T000000Z.iodav3.nc'
 PYTEST_CALLING_DIR = Path(__file__).parent.resolve()
@@ -32,6 +33,12 @@ file_path_ioda_sst_n7_data = os.path.join(
     PYTEST_CALLING_DIR,
     DATA_DIR,
     IODA_SST_N7_DATA
+)
+
+file_path_ioda_sst_nggodas_data = os.path.join(
+    PYTEST_CALLING_DIR,
+    DATA_DIR,
+    IODA_SST_NGGODAS_DATA
 )
 
 file_path_ioda_insitu_data = os.path.join(
@@ -54,6 +61,11 @@ VALID_CONFIG_SST_DICT = {
 VALID_CONFIG_SST_N7_DICT = {
     'harvester_name': hv_registry.IODA_META_NETCDF, 
     'filename': file_path_ioda_sst_n7_data
+}
+
+VALID_CONFIG_SST_NGGODAS_DICT = {
+    'harvester_name': hv_registry.IODA_META_NETCDF, 
+    'filename': file_path_ioda_sst_nggodas_data
 }
 
 VALID_CONFIG_INSITU_DICT = {
@@ -108,6 +120,27 @@ def test_ioda_sst_noaa07_meta():
     assert sst_data.processing_level == "L3U"
     assert sst_data.thinning == None
     assert sst_data.ioda_version == 'v2'
+
+#Test the ioda SST file from nggodas is being parsed correctly, value independently verified
+def test_ioda_sst_nggodas_meta():
+    data = harvest(VALID_CONFIG_SST_NGGODAS_DICT)
+    sst_data = data[0]
+    assert sst_data.filename == IODA_SST_NGGODAS_DATA
+    assert sst_data.file_date_time == '1997-01-05 00:00:00'
+    assert sst_data.num_locs == 284184
+    assert sst_data.min_depth == None
+    assert sst_data.max_depth == None
+    assert sst_data.num_vars == 1
+    assert sst_data.variable_name == 'seaSurfaceTemperature'
+    assert sst_data.var_count == 284184
+    assert sst_data.has_PreQC == True
+    assert sst_data.has_ObsError == True
+    assert sst_data.sensor == None
+    assert sst_data.platform == None
+    assert sst_data.ioda_layout == "ObsGroup"
+    assert sst_data.processing_level == None
+    assert sst_data.thinning == None
+    assert sst_data.ioda_version == 'v3'
 
 #Test insitu data stored in v2 for salinity and temp in one file, values are independently sourced from the file
 def test_ioda_insitu_v2_meta():


### PR DESCRIPTION
This PR addresses legal variations in the ioda versions which exist in NNJA. New iodav3 (SST nggodas) files which are being uploaded have different time formats (just hours, not minutes and seconds since always 00) and don't contain the same num_locs metadata. Expanding the harvester capabilities to handle these two variations, test case included with new file uploaded to the test suite data bucket. All new and old tests are passing. 